### PR TITLE
replace jenkins plugin warnings with warnings-ng

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,9 @@ LABEL org.label-schema.name="Jenkins DSL ready" \
 COPY ./README.md /
 
 
+## Add latest jenkins
+ADD https://updates.jenkins.io/latest/jenkins.war /usr/share/jenkins/jenkins.war
+
 ###############################################################################
 ##                          customize below                                  ##
 ###############################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY ./README.md /
 
 ## Add latest jenkins
 ADD https://updates.jenkins.io/latest/jenkins.war /usr/share/jenkins/jenkins.war
+RUN chmod 644 /usr/share/jenkins/jenkins.war
 
 ###############################################################################
 ##                          customize below                                  ##

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:lts
+FROM jenkins/jenkins:jdk11
 
 USER root
 
@@ -50,8 +50,8 @@ COPY ./README.md /
 
 
 ## Add latest jenkins
-ADD https://updates.jenkins.io/latest/jenkins.war /usr/share/jenkins/jenkins.war
-RUN chmod 644 /usr/share/jenkins/jenkins.war
+# ADD https://updates.jenkins.io/latest/jenkins.war /usr/share/jenkins/jenkins.war
+# RUN chmod 644 /usr/share/jenkins/jenkins.war
 
 ###############################################################################
 ##                          customize below                                  ##

--- a/plugins.txt
+++ b/plugins.txt
@@ -18,6 +18,6 @@ publish-over-ssh
 rebuild
 sidebar-link
 subversion
-warnings
+warnings-ng
 workflow-aggregator
 ws-cleanup


### PR DESCRIPTION
The current container built from scratch returns:

`#13 15.77 Some plugins failed to download! Not downloaded: warnings`

This is due to the `warnings` plugin being removed: https://issues.jenkins.io/browse/INFRA-2487

`warnings-ng` is one replacement for it: https://github.com/jenkinsci/warnings-ng-plugin